### PR TITLE
Remove heavy gif from distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,6 @@ coverage
 node_modules
 npm-debug.log
 src
+demo.gif
+Makefile
+sagui.config.js


### PR DESCRIPTION
Perhaps strategy of exclusion should be reconsidered, I personally prefer to whitelist includes instead. 